### PR TITLE
Update link of LiquidHaskell demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
 <ul>
 <li>Verifying Distributed Programs <a href="./static/pretend_synchrony.pdf">[POPL 2019]</a>, <a href="./static/canonical_sequentialization.pdf">[OOPSLA 2017]</a></li>
 <li>Interaction-based Program Analytics <a href="./static/learning_to_blame.pdf">[OOPSLA 2017]</a>, <a href="./static/dynamic_witnesses_for_static_type_errors.pdf">[ICFP 2016]</a>, <a href="./static/rite.pdf">[PLDI 2020]</a></li>
-<li>Liquid Haskell <a href="./static/lazy_symex.pdf">[PLDI 2019]</a>, <a href="./static/refinement_reflection.pdf">[POPL 2018]</a>, <a href="./static/local_refinement_typing.pdf">[ICFP 2017]</a>, <a href="./static/bounded_refinement_types.pdf">[ICFP 2015]</a>, <a href="http://goto.ucsd.edu/liquid">[Blog]</a></li>
+<li>Liquid Haskell <a href="./static/lazy_symex.pdf">[PLDI 2019]</a>, <a href="./static/refinement_reflection.pdf">[POPL 2018]</a>, <a href="./static/local_refinement_typing.pdf">[ICFP 2017]</a>, <a href="./static/bounded_refinement_types.pdf">[ICFP 2015]</a>, <a href="http://goto.ucsd.edu/liquid/index.html">[Blog]</a></li>
 <li>Data Timing Channels <a href="./static/iodine.pdf">[USENIX Sec 2019]</a>, <a href="./static/fact_dsl.pdf">[PLDI 2019]</a>, <a href="./static/ctfp-ccs18.pdf">[CCS 2018]</a>, <a href="./static/subnormal.pdf">[S&amp;P 2015]</a></li>
 <li>Refined TypeScript <a href="./static/refinement_types_for_typescript.pdf">[PLDI 2016]</a>, <a href="./static/trust_but_verify.pdf">[ECOOP 2015]</a></li>
 </ul>


### PR DESCRIPTION
http://goto.ucsd.edu/liquid/ seems to have shifted to http://goto.ucsd.edu/liquid/index.html